### PR TITLE
Add OrcaSlicer Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,14 +136,15 @@ Currently the following slicers are supported:
 
   * PrusaSlicer
   * SuperSlicer
+  * OrcaSlicer
   * ideaMaker
   * Cura
   * Simplify3D
 
-In PrusaSlicer and SuperSlicer `Post-processing scripts` are set in `Output
+In PrusaSlicer, SuperSlicer, and OrcaSlicer `Post-processing scripts` are set in `Output
 Options` under `Print Settings`:
 
-![PrusaSlicer and SuperSlicer Post-processing scripts option](/doc/post_processing_psss.png)
+![PrusaSlicer, Orcaslicer, and SuperSlicer Post-processing scripts option](/doc/post_processing_psss.png)
 
 Note that ideaMaker does not have support for post-processing scripts, and thus
 cannot automatically run `klipper_estimator` on export.
@@ -197,7 +198,7 @@ line, will trigger this behaviour. Any whitespace between the `;` and `E`
 characters will however be ignored.
 
 The intended usage of this functionality is for print start macros, when
-executed by the slicer. E.g. in PrusaSlicer or SuperSlicer, one might set their
+executed by the slicer. E.g. in PrusaSlicer, SuperSlicer, or OrcaSlicer, one might set their
 print start gcode like this:
 
 ```

--- a/lib/src/slicer.rs
+++ b/lib/src/slicer.rs
@@ -4,6 +4,7 @@ use regex::Regex;
 pub enum SlicerPreset {
     PrusaSlicer { version: String },
     SuperSlicer { version: String },
+    OrcaSlicer { version: String },
     IdeaMaker { version: String },
     Cura { version: Option<String> },
     Simplify3D { version: String },
@@ -14,6 +15,7 @@ impl std::fmt::Display for SlicerPreset {
         match self {
             SlicerPreset::PrusaSlicer { version } => write!(f, "PrusaSlicer {}", version),
             SlicerPreset::SuperSlicer { version } => write!(f, "SuperSlicer {}", version),
+            SlicerPreset::OrcaSlicer { version } => write!(f, "OrcaSlicer {}", version),
             SlicerPreset::IdeaMaker { version } => write!(f, "ideaMaker {}", version),
             SlicerPreset::Cura { version: None } => write!(f, "Cura"),
             SlicerPreset::Cura {
@@ -38,6 +40,7 @@ impl SlicerPreset {
         lazy_static! {
             static ref RE_PRUSA: Regex = Regex::new(r"PrusaSlicer\s(.*)\son").unwrap();
             static ref RE_SUPER: Regex = Regex::new(r"SuperSlicer\s(.*)\son").unwrap();
+            static ref RE_ORCA: Regex = Regex::new(r"OrcaSlicer\s(.*)\son").unwrap();
         }
         if let Some(m) = RE_PRUSA.captures(comment) {
             Some(SlicerPreset::PrusaSlicer {
@@ -45,6 +48,10 @@ impl SlicerPreset {
             })
         } else if let Some(m) = RE_SUPER.captures(comment) {
             Some(SlicerPreset::SuperSlicer {
+                version: m.get(1).unwrap().as_str().into(),
+            })
+        } else if let Some(m) = RE_ORCA.captures(comment) {
+            Some(SlicerPreset::OrcaSlicer {
                 version: m.get(1).unwrap().as_str().into(),
             })
         } else {

--- a/tool/src/cmd/post_process.rs
+++ b/tool/src/cmd/post_process.rs
@@ -303,6 +303,7 @@ fn metadata_processor(preset: &SlicerPreset) -> Box<dyn GCodeInterceptor> {
     match preset {
         SlicerPreset::PrusaSlicer { .. } => Box::<PSSSGCodeInterceptor>::default(),
         SlicerPreset::SuperSlicer { .. } => Box::<PSSSGCodeInterceptor>::default(),
+        SlicerPreset::OrcaSlicer { .. } => Box::<PSSSGCodeInterceptor>::default(),
         SlicerPreset::IdeaMaker { .. } => Box::<IdeaMakerGCodeInterceptor>::default(),
         SlicerPreset::Cura { .. } => Box::<CuraGCodeInterceptor>::default(),
         SlicerPreset::Simplify3D { .. } => Box::<Simplify3DGCodeInterceptor>::default(),


### PR DESCRIPTION
OrcaSlicer is a fork of Bambu Studio, which is a fork of PrusaSlicer, and so on. It uses the same standard slic3r estimate output and is supported by klipper_estimator. However, given how klipper_estimator detected slicers, OrcaSlicer is undetectable because of the output.

This PR aims to support users using OrcaSlicer and updates detection methods, readmes, etc.

![image](https://user-images.githubusercontent.com/15934114/235332473-c8a40eed-d952-4242-9683-c6885decdb1a.png)
![image](https://user-images.githubusercontent.com/15934114/235332492-e64daf91-1426-4b98-a41b-148d60831d41.png)
