### PR TITLE
Give friendlier output on a 401

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ Basic usage info can be found by running `klipper_estimator` with no arguments.
 In order to provide accurate times, `klipper_estimator` needs printer settings
 including maximum velocity, acceleration, etc. It can take these either from a
 config file(`--config_file` option) or grab them directly from Moonraker(using
-the `--config_moonraker_url` option). Note that the Klipper configuration files
-cannot be used directly.
+the `--config_moonraker_url` option and, if authentication is required,
+`--config_moonraker_api_key`). Note that the Klipper configuration files cannot
+be used directly.
 
 To experiment with settings, one can use the `dump-config` command together with
 `--config_moonraker_url` to generate a config file based on the current printer


### PR DESCRIPTION
Currently, if you run `klipper_estimator` and are unable to authenticate (e.g. if you have Moonraker's `force_logins` option enabled), `klipper_estimator`'s output isn't super friendly, despite having support for Moonraker API keys (see #26).

```
./klipper_estimator --config_moonraker_url http://192.168.0.21 dump-config          
Failed to load printer configuration: request failed: error decoding response body: missing field `result` at line 1 column 624
```

This patch changes the config building to check if the status code is 401, and outputs a bespoke message if that happens.

```
./klipper_estimator --config_moonraker_url http://192.168.0.21 dump-config
Failed to load printer configuration: Access denied (you may need to use --config_moonraker_api_key): HTTP status client error (401 Unauthorized) for url (http://192.168.0.21/printer/objects/query?configfile=settings)
```