### PR TITLE
Ensure processed output ends on a new line

### DIFF
--- a/tool/src/cmd/post_process.rs
+++ b/tool/src/cmd/post_process.rs
@@ -437,7 +437,7 @@ impl PostProcessCmd {
             }
         }
 
-        write!(
+        writeln!(
             wr,
             "; Processed by klipper_estimator {}, {}",
             env!("TOOL_VERSION"),


### PR DESCRIPTION
The current output from klipper_estimator does not finish in a new line, which can leave Klipper in a situation where it has finished reading a file but as no `\n` was issued on the last line, the progress never goes to 100%.

So this just ensures that the output does indeed terminate with `\n`.

Related to https://github.com/Klipper3d/klipper/pull/6565